### PR TITLE
修复插入图片再拖拽导致图片无法删除的问题

### DIFF
--- a/add_image_view/src/main/java/me/simple/view/AddImageView.kt
+++ b/add_image_view/src/main/java/me/simple/view/AddImageView.kt
@@ -3,6 +3,7 @@ package me.simple.view
 import android.content.Context
 import android.os.Vibrator
 import android.util.AttributeSet
+import android.util.Log
 import android.util.TypedValue
 import android.view.ViewGroup
 import androidx.recyclerview.widget.GridLayoutManager
@@ -156,6 +157,7 @@ open class AddImageView @JvmOverloads constructor(
      */
     fun removeItem(path: String) {
         val index = mItems.indexOf(path)
+        Log.d("TTT","index = $index")
         if (index == -1) return
         mItems.removeAt(index)
         adapter?.notifyItemRemoved(index)
@@ -268,6 +270,8 @@ open class AddImageView @JvmOverloads constructor(
             position: Int,
             addImageView: AddImageView
         ) {
+            Log.d("TTT","adapterPosition=${holder.adapterPosition}")
+            Log.d("TTT","bindingAdapterPosition=${holder.bindingAdapterPosition}")
             val path = addImageView.getItems()[holder.adapterPosition]
             onBindViewHolder(holder, path, addImageView)
         }
@@ -317,16 +321,20 @@ open class AddImageView @JvmOverloads constructor(
                 if (dragTargetIsAddView(target)) {
                     return false
                 }
-
-                val fromPosition = viewHolder.adapterPosition
-                val toPosition = target.adapterPosition
+                val fromPosition = viewHolder.absoluteAdapterPosition
+                val toPosition = target.absoluteAdapterPosition
                 if (fromPosition != toPosition) {
                     vibrate()
-                    java.util.Collections.swap(mItems, fromPosition, toPosition)
+                    //移动中的 Item
+                    val movingItem = mItems[fromPosition]
+                    //先删除再添加到移动后的位置
+                    mItems.removeAt(fromPosition)
+                    mItems.add(toPosition,movingItem)
+//                    java.util.Collections.swap(mItems, fromPosition, toPosition)
+
                     adapter?.notifyItemMoved(fromPosition, toPosition)
                     return true
                 }
-
                 return true
             }
 

--- a/add_image_view/src/main/java/me/simple/view/AddImageView.kt
+++ b/add_image_view/src/main/java/me/simple/view/AddImageView.kt
@@ -157,7 +157,6 @@ open class AddImageView @JvmOverloads constructor(
      */
     fun removeItem(path: String) {
         val index = mItems.indexOf(path)
-        Log.d("TTT","index = $index")
         if (index == -1) return
         mItems.removeAt(index)
         adapter?.notifyItemRemoved(index)
@@ -270,8 +269,6 @@ open class AddImageView @JvmOverloads constructor(
             position: Int,
             addImageView: AddImageView
         ) {
-            Log.d("TTT","adapterPosition=${holder.adapterPosition}")
-            Log.d("TTT","bindingAdapterPosition=${holder.bindingAdapterPosition}")
             val path = addImageView.getItems()[holder.adapterPosition]
             onBindViewHolder(holder, path, addImageView)
         }

--- a/app/src/main/java/demo/simple/addimageview/CustomItemView.kt
+++ b/app/src/main/java/demo/simple/addimageview/CustomItemView.kt
@@ -1,6 +1,7 @@
 package demo.simple.addimageview
 
 import android.graphics.Bitmap
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -30,7 +31,6 @@ class CustomItemView : AddImageView.ItemViewDelegate<CustomItemView.VH>() {
             .load(path)
             .apply(RequestOptions.bitmapTransform(multi))
             .into(holder.ivCover)
-
         holder.ivDel.setOnClickListener {
             addImageView.removeItem(path)
         }

--- a/app/src/main/java/demo/simple/addimageview/MainActivity.kt
+++ b/app/src/main/java/demo/simple/addimageview/MainActivity.kt
@@ -24,12 +24,20 @@ class MainActivity : AppCompatActivity() {
 
     private val mImages by lazy {
         mutableListOf(
-            "https://gank.io/images/ce66aa74d78f49919085b2b2808ecc50",
-            "https://gank.io/images/02eb8ca3297f4931ab64b7ebd7b5b89c",
-            "https://gank.io/images/0f536c69ada247429b8a9e38d3dba8bb",
-            "https://gank.io/images/ccf0316264d245018fc651cffa6e90de",
-            "https://gank.io/images/95ddb01b6bd34a85aedfda4c9e9bd003",
-            "https://gank.io/images/e92911f5ff9446d5a899b652b1934b93",
+            "https://p.qqan.com/up/2022-2/16454222068823469.jpg",
+            "https://p.qqan.com/up/2022-2/16454222074615293.jpg",
+            "https://p.qqan.com/up/2022-2/16454222079248915.jpg",
+            "https://p.qqan.com/up/2022-2/16454222074882536.jpg",
+            "https://p.qqan.com/up/2022-2/16454222077125944.jpg",
+            "https://p.qqan.com/up/2022-2/16454222079542524.jpg",
+
+//            "https://gank.io/images/ce66aa74d78f49919085b2b2808ecc50",
+//            "https://gank.io/images/02eb8ca3297f4931ab64b7ebd7b5b89c",
+//            "https://gank.io/images/0f536c69ada247429b8a9e38d3dba8bb",
+//            "https://gank.io/images/ccf0316264d245018fc651cffa6e90de",
+//            "https://gank.io/images/95ddb01b6bd34a85aedfda4c9e9bd003",
+//            "https://gank.io/images/e92911f5ff9446d5a899b652b1934b93",
+
 //            "https://gank.io/images/6e57b254da79416bbe58248b570ea85f",
 //            "https://gank.io/images/e0b652d2a0cb46ba888a935c525bd312",
 //            "https://gank.io/images/95ddb01b6bd34a85aedfda4c9e9bd003",


### PR DESCRIPTION
在相册中添加一张本地图片，然后拖拽本地图片将其移动到中间位置，比如从下标6移动到下标4，接着再移除第5和第6张图片，其中有一种会无法移除，这是因为使用`Collections.swap`替换位置后会导致图片下标错乱，从如下的日志可以清楚看到：

> --------------拖拽前--------------
0：https://p.qqan.com/up/2022-2/16454222068823469.jpg
1：https://p.qqan.com/up/2022-2/16454222074615293.jpg
2：https://p.qqan.com/up/2022-2/16454222079248915.jpg
3：https://p.qqan.com/up/2022-2/16454222074882536.jpg
4：https://p.qqan.com/up/2022-2/16454222077125944.jpg
5：https://p.qqan.com/up/2022-2/16454222079542524.jpg
6：/storage/emulated/0/Pictures/知乎/1652198422920.jpeg
--------------拖拽后--------------
0：https://p.qqan.com/up/2022-2/16454222068823469.jpg
1：https://p.qqan.com/up/2022-2/16454222074615293.jpg
2：https://p.qqan.com/up/2022-2/16454222079248915.jpg
3：https://p.qqan.com/up/2022-2/16454222074882536.jpg
4：/storage/emulated/0/Pictures/知乎/1652198422920.jpeg
5：https://p.qqan.com/up/2022-2/16454222079542524.jpg
6：https://p.qqan.com/up/2022-2/16454222077125944.jpg

正确的结果应该是下标 6 移动到下标 4 后，原来的 4 和 5 依次变成 5 和 6，但只替换的话原来的 5 没有变化。由于删除时是按照下标删除的，会导致删除出错。所以拖拽后应该先将移动的图片从集合中移除，再插入相应的位置。
